### PR TITLE
Fix JSON parsing error from aider MCP server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to Aider MCP Server
+
+## Development Setup
+
+1. Clone the repository
+2. Install development dependencies with `hatch shell`
+3. Install pre-commit hooks: `hatch run dev:install-hooks`
+
+## Code Formatting
+
+To ensure consistency between local development and CI:
+
+### Before Committing
+
+Always run the formatter before committing:
+
+```bash
+hatch run dev:format
+```
+
+This will:
+- Sort imports with `isort`
+- Format code with `ruff format`
+- Fix linting issues with `ruff check --fix`
+
+### Linting
+
+To run all linters without fixing:
+
+```bash
+hatch run dev:lint
+```
+
+### Running Everything
+
+To format, lint, and test in one command:
+
+```bash
+hatch run dev:all
+```
+
+### Manual Commands
+
+If you need to run individual tools:
+
+```bash
+# Format imports
+hatch -e dev run isort . --profile black
+
+# Format code
+hatch -e dev run ruff format .
+
+# Fix linting issues
+hatch -e dev run ruff check --fix .
+
+# Run all pre-commit checks
+hatch -e dev run pre-commit run --all-files
+```
+
+## Writing Tests
+
+- Place test files in the `tests/` directory
+- Name test files with `test_` prefix
+- Security checks are relaxed for test files (S101, S108)
+
+## Pull Requests
+
+1. Create a feature branch from `development`
+2. Make your changes
+3. Run `hatch run dev:all` to format, lint, and test
+4. Commit your changes
+5. Open a PR against the `development` branch
+
+## CI/CD
+
+The CI will:
+1. Run pre-commit hooks on all files
+2. Fail if any formatting changes are needed
+3. Run tests across multiple Python versions
+
+To avoid CI failures, always run `hatch run dev:format` or `hatch run dev:lint` before pushing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,24 @@ packages = ["src/aider_mcp_server"]
 dependencies = ["aider-mcp-server[dev]"]
 features = ["dev"]
 
+[tool.hatch.envs.dev.scripts]
+# Format and lint commands
+format = [
+    "isort . --profile black",
+    "ruff format .",
+    "ruff check --fix .",
+]
+lint = "pre-commit run --all-files"
+test = "pytest {args}"
+all = [
+    "format",
+    "lint",
+    "test",
+]
+# Pre-commit management
+install-hooks = "pre-commit install --install-hooks"
+update-hooks = "pre-commit autoupdate"
+
 [tool.hatch.envs.test]
 dependencies = ["aider-mcp-server[test]"]
 features = ["test"]
@@ -97,7 +115,8 @@ line-length = 120
 select = ["E", "F", "A", "B", "C", "Q", "S"]  # Removed "I" for isort
 ignore = ["E501"]  # Ignore line length
 # Ignore S101 (assert usage) in test files and exclude stubbed file from formatting
-per-file-ignores = {"tests/*" = ["S101"], "src/aider_mcp_server/stubs/sse_starlette.pyi" = ["E", "F", "I", "A", "B", "C", "Q", "S"]}
+# Allow S108 (/tmp usage) in test files
+per-file-ignores = {"tests/*" = ["S101"], "test_*.py" = ["S101", "S108"], "src/aider_mcp_server/stubs/sse_starlette.pyi" = ["E", "F", "I", "A", "B", "C", "Q", "S"]}
 
 [tool.ruff.format]
 quote-style = "double"

--- a/test_json_output.py
+++ b/test_json_output.py
@@ -3,21 +3,23 @@
 
 import asyncio
 import json
-from unittest.mock import Mock, patch
+import tempfile
+from unittest.mock import patch
+
 from aider_mcp_server.atoms.tools.aider_ai_code import code_with_aider, init_diff_cache, shutdown_diff_cache
 
 
 class MockCoder:
     """Mock Aider Coder that simulates the problematic output"""
-    
+
     def __init__(self, *args, **kwargs):
         pass
-        
+
     def run(self, prompt):
         # Simulate the problematic behavior where Aider prints to stdout
         print("Creating empty file test.py")
         return "Mock execution completed"
-        
+
     @staticmethod
     def create(*args, **kwargs):
         return MockCoder()
@@ -25,7 +27,7 @@ class MockCoder:
 
 class MockInputOutput:
     """Mock InputOutput class"""
-    
+
     def __init__(self, *args, **kwargs):
         self.yes_to_all = True
         self.tool_error = False
@@ -38,38 +40,41 @@ class MockInputOutput:
 
 class MockModel:
     """Mock Model class"""
-    
+
     def __init__(self, *args, **kwargs):
         pass
-        
+
     def commit_message_models(self):
         return []
 
 
 async def test_json_output():
     """Test that only JSON is output from the code_with_aider function"""
-    
+
     # Initialize diff cache
     await init_diff_cache()
-    
-    # Mock the Aider components
-    with patch('aider_mcp_server.atoms.tools.aider_ai_code.Coder', MockCoder), \
-         patch('aider_mcp_server.atoms.tools.aider_ai_code.InputOutput', MockInputOutput), \
-         patch('aider_mcp_server.atoms.tools.aider_ai_code.Model', MockModel):
-        
-        # Test the code_with_aider function
-        result = await code_with_aider(
-            ai_coding_prompt="Add a test function",
-            relative_editable_files=["test.py"],
-            relative_readonly_files=[],
-            model="test-model",
-            working_dir="/tmp/test",
-        )
-        
+
+    # Create a temporary directory for the test
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Mock the Aider components
+        with (
+            patch("aider_mcp_server.atoms.tools.aider_ai_code.Coder", MockCoder),
+            patch("aider_mcp_server.atoms.tools.aider_ai_code.InputOutput", MockInputOutput),
+            patch("aider_mcp_server.atoms.tools.aider_ai_code.Model", MockModel),
+        ):
+            # Test the code_with_aider function
+            result = await code_with_aider(
+                ai_coding_prompt="Add a test function",
+                relative_editable_files=["test.py"],
+                relative_readonly_files=[],
+                model="test-model",
+                working_dir=temp_dir,
+            )
+
         print("=== RAW RESULT ===")
         print(repr(result))
         print("=== END RAW RESULT ===")
-        
+
         # Try to parse the result as JSON
         try:
             parsed = json.loads(result)
@@ -78,11 +83,11 @@ async def test_json_output():
         except json.JSONDecodeError as e:
             print(f"ERROR: Result is not valid JSON: {e}")
             print(f"Result: {result}")
-            
+
             # Check if there's non-JSON data at the beginning
-            if not result.startswith('{'):
+            if not result.startswith("{"):
                 print(f"Non-JSON data detected at start: {result[:50]}...")
-    
+
     # Shutdown diff cache
     await shutdown_diff_cache()
 

--- a/test_json_output.py
+++ b/test_json_output.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Test script to verify JSON output from aider MCP server"""
+
+import asyncio
+import json
+from unittest.mock import Mock, patch
+from aider_mcp_server.atoms.tools.aider_ai_code import code_with_aider, init_diff_cache, shutdown_diff_cache
+
+
+class MockCoder:
+    """Mock Aider Coder that simulates the problematic output"""
+    
+    def __init__(self, *args, **kwargs):
+        pass
+        
+    def run(self, prompt):
+        # Simulate the problematic behavior where Aider prints to stdout
+        print("Creating empty file test.py")
+        return "Mock execution completed"
+        
+    @staticmethod
+    def create(*args, **kwargs):
+        return MockCoder()
+
+
+class MockInputOutput:
+    """Mock InputOutput class"""
+    
+    def __init__(self, *args, **kwargs):
+        self.yes_to_all = True
+        self.tool_error = False
+        self.dry_run = False
+        self.quiet = True
+        self.output = None
+        self.tool_output = None
+        self.tool_error_output = None
+
+
+class MockModel:
+    """Mock Model class"""
+    
+    def __init__(self, *args, **kwargs):
+        pass
+        
+    def commit_message_models(self):
+        return []
+
+
+async def test_json_output():
+    """Test that only JSON is output from the code_with_aider function"""
+    
+    # Initialize diff cache
+    await init_diff_cache()
+    
+    # Mock the Aider components
+    with patch('aider_mcp_server.atoms.tools.aider_ai_code.Coder', MockCoder), \
+         patch('aider_mcp_server.atoms.tools.aider_ai_code.InputOutput', MockInputOutput), \
+         patch('aider_mcp_server.atoms.tools.aider_ai_code.Model', MockModel):
+        
+        # Test the code_with_aider function
+        result = await code_with_aider(
+            ai_coding_prompt="Add a test function",
+            relative_editable_files=["test.py"],
+            relative_readonly_files=[],
+            model="test-model",
+            working_dir="/tmp/test",
+        )
+        
+        print("=== RAW RESULT ===")
+        print(repr(result))
+        print("=== END RAW RESULT ===")
+        
+        # Try to parse the result as JSON
+        try:
+            parsed = json.loads(result)
+            print("SUCCESS: Result is valid JSON")
+            print(json.dumps(parsed, indent=2))
+        except json.JSONDecodeError as e:
+            print(f"ERROR: Result is not valid JSON: {e}")
+            print(f"Result: {result}")
+            
+            # Check if there's non-JSON data at the beginning
+            if not result.startswith('{'):
+                print(f"Non-JSON data detected at start: {result[:50]}...")
+    
+    # Shutdown diff cache
+    await shutdown_diff_cache()
+
+
+if __name__ == "__main__":
+    asyncio.run(test_json_output())


### PR DESCRIPTION
## Summary
- Fix issue where Aider's stdout messages were being sent to clients before JSON response
- Implement comprehensive stdout/stderr capture and IO output suppression

## Description
When sending a request to the aider MCP server, clients were receiving the error:
```
MCP server "aider" SyntaxError: Unexpected token 'C', "Creating empty file" is not valid JSON
```

This was caused by the Aider library outputting messages like "Creating empty file" directly to stdout, which was interfering with the JSON response sent to the client.

## Changes
1. Enhanced stdout/stderr capture at the earliest point in `code_with_aider` function
2. Improved IO output suppression in `_setup_aider_coder`:
   - Redirect IO output to `/dev/null` instead of just a StringIO buffer
   - Set additional suppression attributes (`tool_output` and `tool_error_output` to None)
   - Enable quiet mode on the IO object
   - Add `verbose=False` and `quiet=True` parameters to `Coder.create()` call
3. Fixed import issue caught by pre-commit hooks
4. Added test script to verify JSON output is properly formatted

## Test Plan
- [x] Added `test_json_output.py` that simulates the problematic behavior
- [x] Verified that only valid JSON is output from the `code_with_aider` function
- [x] All pre-commit hooks pass

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

🤖 Generated with [Claude Code](https://claude.ai/code)